### PR TITLE
Make Metadata store account for IOExceptions

### DIFF
--- a/rcloud-gist-service/src/main/java/com/mangosolutions/rcloud/rawgist/model/GistCommentResponse.java
+++ b/rcloud-gist-service/src/main/java/com/mangosolutions/rcloud/rawgist/model/GistCommentResponse.java
@@ -118,4 +118,65 @@ public class GistCommentResponse implements Serializable {
 		this.additionalProperties.putAll(properties);
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((additionalProperties == null) ? 0 : additionalProperties.hashCode());
+		result = prime * result + ((body == null) ? 0 : body.hashCode());
+		result = prime * result + ((createdAt == null) ? 0 : createdAt.hashCode());
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((updatedAt == null) ? 0 : updatedAt.hashCode());
+		result = prime * result + ((url == null) ? 0 : url.hashCode());
+		result = prime * result + ((user == null) ? 0 : user.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		GistCommentResponse other = (GistCommentResponse) obj;
+		if (additionalProperties == null) {
+			if (other.additionalProperties != null)
+				return false;
+		} else if (!additionalProperties.equals(other.additionalProperties))
+			return false;
+		if (body == null) {
+			if (other.body != null)
+				return false;
+		} else if (!body.equals(other.body))
+			return false;
+		if (createdAt == null) {
+			if (other.createdAt != null)
+				return false;
+		} else if (!createdAt.equals(other.createdAt))
+			return false;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (updatedAt == null) {
+			if (other.updatedAt != null)
+				return false;
+		} else if (!updatedAt.equals(other.updatedAt))
+			return false;
+		if (url == null) {
+			if (other.url != null)
+				return false;
+		} else if (!url.equals(other.url))
+			return false;
+		if (user == null) {
+			if (other.user != null)
+				return false;
+		} else if (!user.equals(other.user))
+			return false;
+		return true;
+	}
+
 }

--- a/rcloud-gist-service/src/main/java/com/mangosolutions/rcloud/rawgist/repository/git/GistMetadata.java
+++ b/rcloud-gist-service/src/main/java/com/mangosolutions/rcloud/rawgist/repository/git/GistMetadata.java
@@ -152,4 +152,74 @@ public class GistMetadata implements Serializable {
 		return this.forkOf;
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (_public ? 1231 : 1237);
+		result = prime * result + ((additionalProperties == null) ? 0 : additionalProperties.hashCode());
+		result = prime * result + ((createdAt == null) ? 0 : createdAt.hashCode());
+		result = prime * result + ((description == null) ? 0 : description.hashCode());
+		result = prime * result + ((forkOf == null) ? 0 : forkOf.hashCode());
+		result = prime * result + ((forks == null) ? 0 : forks.hashCode());
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + ((owner == null) ? 0 : owner.hashCode());
+		result = prime * result + ((updatedAt == null) ? 0 : updatedAt.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		GistMetadata other = (GistMetadata) obj;
+		if (_public != other._public)
+			return false;
+		if (additionalProperties == null) {
+			if (other.additionalProperties != null)
+				return false;
+		} else if (!additionalProperties.equals(other.additionalProperties))
+			return false;
+		if (createdAt == null) {
+			if (other.createdAt != null)
+				return false;
+		} else if (!createdAt.equals(other.createdAt))
+			return false;
+		if (description == null) {
+			if (other.description != null)
+				return false;
+		} else if (!description.equals(other.description))
+			return false;
+		if (forkOf == null) {
+			if (other.forkOf != null)
+				return false;
+		} else if (!forkOf.equals(other.forkOf))
+			return false;
+		if (forks == null) {
+			if (other.forks != null)
+				return false;
+		} else if (!forks.equals(other.forks))
+			return false;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		if (owner == null) {
+			if (other.owner != null)
+				return false;
+		} else if (!owner.equals(other.owner))
+			return false;
+		if (updatedAt == null) {
+			if (other.updatedAt != null)
+				return false;
+		} else if (!updatedAt.equals(other.updatedAt))
+			return false;
+		return true;
+	}
+	
 }

--- a/rcloud-gist-service/src/test/java/com/mangosolutions/rcloud/rawgist/repository/GistCommentStoreTest.java
+++ b/rcloud-gist-service/src/test/java/com/mangosolutions/rcloud/rawgist/repository/GistCommentStoreTest.java
@@ -1,3 +1,9 @@
+/*******************************************************************************
+* Copyright (c) 2018 AT&T Intellectual Property, [http://www.att.com]
+*
+* SPDX-License-Identifier:   MIT
+*
+*******************************************************************************/
 package com.mangosolutions.rcloud.rawgist.repository;
 
 import static org.junit.Assert.assertEquals;
@@ -19,6 +25,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+import com.google.common.io.Files;
 import com.mangosolutions.rcloud.rawgist.model.GistCommentResponse;
 import com.mangosolutions.rcloud.rawgist.repository.git.GistCommentStore;
 
@@ -97,10 +104,30 @@ public class GistCommentStoreTest {
 			instance.save(outputFile, comments2);
 			fail("Expected gist error provoked by IOException thrown by ObjectMapper");
 		} catch (GistRepositoryError error) {
-			// not interested
+			// expected, no need to process
 		}
 
 		instance.setObjectMapper(functionalObjectMapper);
+		List<GistCommentResponse> result = instance.load(outputFile);
+
+		assertEquals("Initial comments should be loaded from the comments file", comments, result);
+		
+	}
+	
+	@Test
+	public void shouldLoadStateFromWorkingCopyIfMainFileDoesNotExist() throws IOException {
+		File testDir = tempFolder.newFolder();
+		File outputFile = new File(testDir, "comments.json");
+
+		GistCommentResponse comment = new GistCommentResponse();
+		comment.setBody(MOCK_BODY);
+		comment.setId(MOCK_ID);
+		List<GistCommentResponse> comments = Lists.newArrayList(comment);
+
+		instance.save(outputFile, comments);
+		
+		Files.move(outputFile, new File(outputFile.getParentFile(), outputFile.getName() + ".tmp"));
+
 		List<GistCommentResponse> result = instance.load(outputFile);
 
 		assertEquals("Initial comments should be loaded from the comments file", comments, result);

--- a/rcloud-gist-service/src/test/java/com/mangosolutions/rcloud/rawgist/repository/GistCommentStoreTest.java
+++ b/rcloud-gist-service/src/test/java/com/mangosolutions/rcloud/rawgist/repository/GistCommentStoreTest.java
@@ -1,0 +1,109 @@
+package com.mangosolutions.rcloud.rawgist.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doThrow;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import com.mangosolutions.rcloud.rawgist.model.GistCommentResponse;
+import com.mangosolutions.rcloud.rawgist.repository.git.GistCommentStore;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GistCommentStoreTest {
+
+	private GistCommentStore instance = new GistCommentStore();
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Mock
+	private ObjectMapper mockObjectMapper;
+
+	private static final String MOCK_BODY = "Some description";
+	private static final long MOCK_ID = 1234l;
+
+	@Test
+	public void shouldCreateNewCommentsFile() throws IOException {
+		File testDir = tempFolder.newFolder();
+		File outputFile = new File(testDir, "comments.json");
+
+		GistCommentResponse comment = new GistCommentResponse();
+		comment.setBody(MOCK_BODY);
+		comment.setId(MOCK_ID);
+		List<GistCommentResponse> comments = Lists.newArrayList(comment);
+
+		instance.save(outputFile, comments);
+
+		List<GistCommentResponse> result = instance.load(outputFile);
+		assertEquals(comments, result);
+	}
+
+	@Test
+	public void shouldUpdateExistingCommentsFile() throws IOException {
+		File testDir = tempFolder.newFolder();
+		File outputFile = new File(testDir, "comments.json");
+
+		outputFile.createNewFile();
+
+		GistCommentResponse comment = new GistCommentResponse();
+		comment.setBody(MOCK_BODY);
+		comment.setId(MOCK_ID);
+		List<GistCommentResponse> comments = Lists.newArrayList(comment);
+
+		instance.save(outputFile, comments);
+		
+		List<GistCommentResponse> result = instance.load(outputFile);
+		assertEquals(comments, result);
+	}
+
+	@Test
+	public void shouldNotUpdateExistingCommentsFileInCaseOfError() throws IOException {
+		File testDir = tempFolder.newFolder();
+		File outputFile = new File(testDir, "comments.json");
+
+		GistCommentResponse comment = new GistCommentResponse();
+		comment.setBody(MOCK_BODY);
+		comment.setId(MOCK_ID);
+		List<GistCommentResponse> comments = Lists.newArrayList(comment);
+
+		instance.save(outputFile, comments);
+
+		GistCommentResponse comment2 = new GistCommentResponse();
+		comment2.setBody("Second comment");
+		comment2.setId(2345l);
+		List<GistCommentResponse> comments2 = Lists.newArrayList(comments);
+		comments2.add(comment2);
+
+		doThrow(IOException.class).when(mockObjectMapper).writeValue(any(File.class), same(comments2));
+		ObjectMapper functionalObjectMapper = instance.getObjectMapper();
+
+		instance.setObjectMapper(mockObjectMapper);
+
+		try {
+			instance.save(outputFile, comments2);
+			fail("Expected gist error provoked by IOException thrown by ObjectMapper");
+		} catch (GistRepositoryError error) {
+			// not interested
+		}
+
+		instance.setObjectMapper(functionalObjectMapper);
+		List<GistCommentResponse> result = instance.load(outputFile);
+
+		assertEquals("Initial comments should be loaded from the comments file", comments, result);
+		
+	}
+}

--- a/rcloud-gist-service/src/test/java/com/mangosolutions/rcloud/rawgist/repository/GistMetadataStoreTest.java
+++ b/rcloud-gist-service/src/test/java/com/mangosolutions/rcloud/rawgist/repository/GistMetadataStoreTest.java
@@ -1,0 +1,99 @@
+package com.mangosolutions.rcloud.rawgist.repository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doThrow;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mangosolutions.rcloud.rawgist.repository.git.GistMetadata;
+import com.mangosolutions.rcloud.rawgist.repository.git.GistMetadataStore;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GistMetadataStoreTest {
+
+	private GistMetadataStore instance = new GistMetadataStore();
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Mock
+	private ObjectMapper mockObjectMapper;
+
+	private static final String MOCK_DESCRIPTION = "Some description";
+	private static final String MOCK_ID = "Some id";
+
+	@Test
+	public void shouldCreateNewMetadataFile() throws IOException {
+		File testDir = tempFolder.newFolder();
+		File outputFile = new File(testDir, "gist.json");
+
+		GistMetadata gistMetadata = new GistMetadata();
+		gistMetadata.setDescription(MOCK_DESCRIPTION);
+		gistMetadata.setId(MOCK_ID);
+		instance.save(outputFile, gistMetadata);
+
+		GistMetadata result = instance.load(outputFile);
+		assertEquals(gistMetadata, result);
+	}
+
+	@Test
+	public void shouldUpdateExistingMetadataFile() throws IOException {
+		File testDir = tempFolder.newFolder();
+		File outputFile = new File(testDir, "gist.json");
+
+		outputFile.createNewFile();
+
+		GistMetadata gistMetadata = new GistMetadata();
+		gistMetadata.setDescription(MOCK_DESCRIPTION);
+		gistMetadata.setId(MOCK_ID);
+		instance.save(outputFile, gistMetadata);
+
+		GistMetadata result = instance.load(outputFile);
+		assertEquals(gistMetadata, result);
+	}
+
+	@Test
+	public void shouldNotUpdateExistingMetadataFileInCaseOfError() throws IOException {
+		File testDir = tempFolder.newFolder();
+		File outputFile = new File(testDir, "gist.json");
+
+		GistMetadata gistMetadata = new GistMetadata();
+		gistMetadata.setDescription(MOCK_DESCRIPTION);
+		gistMetadata.setId(MOCK_ID);
+		instance.save(outputFile, gistMetadata);
+
+		GistMetadata gistMetadataNew = new GistMetadata();
+		gistMetadataNew.setDescription(MOCK_DESCRIPTION);
+		gistMetadataNew.setId(MOCK_ID);
+		gistMetadataNew.setOwner("Someone");
+
+		doThrow(IOException.class).when(mockObjectMapper).writeValue(any(File.class), same(gistMetadataNew));
+		ObjectMapper functionalObjectMapper = instance.getObjectMapper();
+
+		instance.setObjectMapper(mockObjectMapper);
+
+		try {
+			instance.save(outputFile, gistMetadata);
+			fail("Expected gist error provoked by IOException thrown by ObjectMapper");
+		} catch (GistRepositoryError error) {
+			// not interested
+		}
+
+		instance.setObjectMapper(functionalObjectMapper);
+		GistMetadata result = instance.load(outputFile);
+
+		assertEquals("Initial Gist metadata should be loaded from metadata file", gistMetadata, result);
+	}
+}

--- a/rcloud-gist-service/src/test/java/com/mangosolutions/rcloud/rawgist/repository/GistMetadataStoreTest.java
+++ b/rcloud-gist-service/src/test/java/com/mangosolutions/rcloud/rawgist/repository/GistMetadataStoreTest.java
@@ -1,3 +1,9 @@
+/*******************************************************************************
+* Copyright (c) 2018 AT&T Intellectual Property, [http://www.att.com]
+*
+* SPDX-License-Identifier:   MIT
+*
+*******************************************************************************/
 package com.mangosolutions.rcloud.rawgist.repository;
 
 import static org.junit.Assert.assertEquals;
@@ -17,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Files;
 import com.mangosolutions.rcloud.rawgist.repository.git.GistMetadata;
 import com.mangosolutions.rcloud.rawgist.repository.git.GistMetadataStore;
 
@@ -85,13 +92,30 @@ public class GistMetadataStoreTest {
 		instance.setObjectMapper(mockObjectMapper);
 
 		try {
-			instance.save(outputFile, gistMetadata);
+			instance.save(outputFile, gistMetadataNew);
 			fail("Expected gist error provoked by IOException thrown by ObjectMapper");
 		} catch (GistRepositoryError error) {
-			// not interested
+			// expected, no need to process
 		}
 
 		instance.setObjectMapper(functionalObjectMapper);
+		GistMetadata result = instance.load(outputFile);
+
+		assertEquals("Initial Gist metadata should be loaded from metadata file", gistMetadata, result);
+	}
+	
+	@Test
+	public void shouldLoadStateFromTmpStateFileIfMainFileDoesNotExist() throws IOException {
+		File testDir = tempFolder.newFolder();
+		File outputFile = new File(testDir, "gist.json");
+
+		GistMetadata gistMetadata = new GistMetadata();
+		gistMetadata.setDescription(MOCK_DESCRIPTION);
+		gistMetadata.setId(MOCK_ID);
+		instance.save(outputFile, gistMetadata);
+		
+		Files.move(outputFile, new File(outputFile.getParentFile(), outputFile.getName() + ".tmp"));
+
 		GistMetadata result = instance.load(outputFile);
 
 		assertEquals("Initial Gist metadata should be loaded from metadata file", gistMetadata, result);


### PR DESCRIPTION
Updated GistMetadataStore and GistCommentStore so they handle possible IOExceptions thrown (and unexpected failures) during updates to JSON files.

The implementation (of both) is as follows:
* they always write to a working copy of a file
* if writing to a working copy fails, it is deleted.
* if there happens to be an exception thrown during replacement of the main copy with the working copy, the state is recovered from the working copy
* if it happens that both - working copy and main file is there, working copy is ignored.

I covered the changes with unit tests, however I haven't performed any integration tests with RCloud, as I don't have RCloud configured to work with rcloud-gist-service (yet).

FIX #2 

